### PR TITLE
New static_transform_manager package.

### DIFF
--- a/static_transform_manager/CMakeLists.txt
+++ b/static_transform_manager/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(static_transform_manager)
+
+find_package(catkin REQUIRED COMPONENTS
+  geometry_msgs
+  message_generation
+  rospy
+  std_msgs
+  tf
+)
+
+
+## Generate services in the 'srv' folder
+add_service_files(
+  FILES
+  SetTransformation.srv
+  StopTransformation.srv
+)
+
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  geometry_msgs
+  std_msgs
+)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES static_transform_manager
+#  CATKIN_DEPENDS geometry_msgs message_generation rospy std_msgs tf
+#  DEPENDS system_lib
+)
+
+install(PROGRAMS
+  scripts/static_tf_services.py
+  scripts/rviz_click_to_tf.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/static_transform_manager/README.md
+++ b/static_transform_manager/README.md
@@ -1,0 +1,26 @@
+static_transform_manager
+========================
+
+This provides a transformation manager node that broadcasts static transformations at 30Hz, in the same way that static transformations can
+be created using static_tf_broadcaster. Using this node static transformations can be easier setup and removed than managing a static_tf_broadcasters as sub processes.
+
+### Usage
+
+```
+rosrun static_transform_manager static_tf_services.py
+```
+
+will start the manager node. This provides two services:
+
+- /static_transforms_manager/set_tf
+- /static_transforms_manager/stop_tf
+
+`set_tf` takes a single argument `geometry_msgs/TransformStamped transform`,
+and returns a debug string `response` and a bool `success`. The supplied transform is broadcast at 30Hz.
+
+`stop_tf` takes a single argument `string child_frame_id` which is the child frame to stop broadcasting.
+
+### Example
+
+`rosrun static_transform_manager rviz_click_to_tf.py` will listen to points clicked in rviz and turn them into a transformation in the TF tree.
+

--- a/static_transform_manager/package.xml
+++ b/static_transform_manager/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package>
+  <name>static_transform_manager</name>
+  <version>0.1.2</version>
+  <description>
+    The static_transform_manager package provides a node providing services to set
+	static transformations, similar to starting a tf/static_transform_publisher node.
+  </description>
+
+  <maintainer email="cburbridge@gmail.com">Chris Burbridge</maintainer>
+  <author email="cburbridge@gmail.com">Chris Burbridge</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>tf</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/static_transform_manager/scripts/rviz_click_to_tf.py
+++ b/static_transform_manager/scripts/rviz_click_to_tf.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import rospy
+import tf
+from geometry_msgs.msg import PointStamped, TransformStamped
+from static_transform_manager.srv import ( SetTransformation,
+                                            SetTransformationResponse, 
+                                            StopTransformation,
+                                            StopTransformationResponse
+                                        )
+class RVizClickToTF(object):
+    def __init__(self, frame_name):
+        self._frame_name = frame_name
+        self._click_sub = rospy.Subscriber("/clicked_point",
+                                           PointStamped,
+                                           self._on_clicked)
+        self._set_transform =  rospy.ServiceProxy("/static_transforms_manager/set_tf",
+                                                  SetTransformation)
+
+
+    def _on_clicked(self, pt):
+        t = TransformStamped()
+        t.child_frame_id = "clicked"
+        t.header.frame_id = pt.header.frame_id 
+        t.transform.translation.x = pt.point.x 
+        t.transform.translation.y = pt.point.y
+        t.transform.rotation.w = 1
+        self._set_transform(t)
+
+
+if __name__ == "__main__":
+    rospy.init_node("ptu_follow_frame_click_tester")
+    click_to_tf = RVizClickToTF("clicked")
+    rospy.spin()
+

--- a/static_transform_manager/scripts/static_tf_services.py
+++ b/static_transform_manager/scripts/static_tf_services.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+import rospy
+import tf
+from ptu_follow_frame.srv import ( SetTransformation, SetTransformationResponse, 
+                                   StopTransformation, StopTransformationResponse
+                                   )
+
+
+class StaticTransformationsManager(object):
+    def __init__(self, freq):
+        self._tf_broadcaster =  tf.TransformBroadcaster()
+        self._rater =  rospy.Rate(freq)
+        self._running =  True
+        self._transforms = {} # Indexed by child name
+        
+        # set up services
+        self._start_srv = rospy.Service(rospy.get_name()+"/set_tf",
+                                        SetTransformation,
+                                        self._start_transform_srv)
+        self._start_srv = rospy.Service(rospy.get_name()+"/stop_tf",
+                                        StopTransformation,
+                                        self._stop_tranform_srv)
+        pass
+    
+    def _start_transform_srv(self, req):
+        resp =  SetTransformationResponse()
+        self._transforms[req.transform.child_frame_id] = req.transform
+        resp.is_ok = True
+        resp.response =  "Frame added"
+        return resp
+    
+    def _stop_tranform_srv(self, req):
+        resp =  StopTransformationResponse()
+        if self._transforms.has_key(req.child_frame_id):
+            self._transforms.pop(req.child_frame_id)
+            resp.response =  "ok"
+            resp.is_ok =  True
+        else:
+            resp.response =  "frame not known by this managerx"
+            resp.is_ok = False
+        return resp
+    
+    def start(self):
+        while self._running and not rospy.is_shutdown():
+            self._rater.sleep()
+            for transform in self._transforms.values():
+                self._tf_broadcaster.sendTransform((transform.transform.translation.x,
+                                                    transform.transform.translation.y,
+                                                    transform.transform.translation.z), 
+                                                   (transform.transform.rotation.x,
+                                                    transform.transform.rotation.y,
+                                                    transform.transform.rotation.z,
+                                                    transform.transform.rotation.w), 
+                                                   rospy.Time.now(),
+                                                   transform.child_frame_id,
+                                                   transform.header.frame_id)
+
+                
+if __name__ == '__main__':
+    ''' Main Program '''
+    rospy.init_node("static_transforms_manager")
+    manager = StaticTransformationsManager(30)
+    manager.start()

--- a/static_transform_manager/srv/SetTransformation.srv
+++ b/static_transform_manager/srv/SetTransformation.srv
@@ -1,0 +1,4 @@
+geometry_msgs/TransformStamped transform
+---
+string response
+bool is_ok

--- a/static_transform_manager/srv/StopTransformation.srv
+++ b/static_transform_manager/srv/StopTransformation.srv
@@ -1,0 +1,3 @@
+string child_frame_id
+---
+string response


### PR DESCRIPTION
This provides a transformation manager node that broadcasts static transformations at 30Hz, in the same way that static transformations can be created using static_tf_broadcaster. Using this node static transformations can be easier setup and removed than managing a static_tf_broadcasters as sub processes.

Currently using for object learning, but it is generically useful.
