### PR TITLE
Add is_ok flag to StopTransformation response.

### DIFF
--- a/static_transform_manager/srv/StopTransformation.srv
+++ b/static_transform_manager/srv/StopTransformation.srv
@@ -1,3 +1,5 @@
 string child_frame_id
 ---
 string response
+bool is_ok
+


### PR DESCRIPTION
This adds a missing `is_ok` field for the transformation managers response to stopping. It is used in the code, but got missed in the service definition.
