### PR TITLE
adding wait to the door passing action

### DIFF
--- a/door_pass/CMakeLists.txt
+++ b/door_pass/CMakeLists.txt
@@ -29,6 +29,7 @@ catkin_python_setup()
 add_message_files(
   FILES
   DoorCheckStat.msg
+  DoorWaitStat.msg
 )
 
 add_action_files(

--- a/door_pass/CMakeLists.txt
+++ b/door_pass/CMakeLists.txt
@@ -35,12 +35,14 @@ add_action_files(
     DIRECTORY action 
     FILES 
     DoorCheck.action
+    DoorWait.action
 )
 
 generate_messages(
     DEPENDENCIES
     std_msgs 
     actionlib_msgs
+    geometry_msgs
 )
 
 catkin_package(

--- a/door_pass/action/DoorWait.action
+++ b/door_pass/action/DoorWait.action
@@ -1,0 +1,6 @@
+geometry_msgs/PoseStamped target_pose
+float64 wait_timeout
+---
+bool open
+---
+

--- a/door_pass/launch/door_passing.launch
+++ b/door_pass/launch/door_passing.launch
@@ -1,4 +1,6 @@
 <launch>
     <node pkg="door_pass" type="door_passing.py" name="door_passing"  output="screen"/>
     <node pkg="door_pass" type="door_checking.py" name="door_checking"  output="screen"/>
+    <node pkg="door_pass" type="door_wait_and_pass.py" name="door_wait_and_pass"  output="screen"/>
+    <node pkg="door_pass" type="door_waiting.py" name="door_waiting"  output="screen"/>
 </launch>

--- a/door_pass/msg/DoorWaitStat.msg
+++ b/door_pass/msg/DoorWaitStat.msg
@@ -1,0 +1,4 @@
+string topological_map_name
+string waypoint
+bool opened
+float64 wait_time

--- a/door_pass/package.xml
+++ b/door_pass/package.xml
@@ -38,6 +38,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>mongodb_store</run_depend>
+  <run_depend>mary_tts</run_depend>
 
   <export/>
 </package>

--- a/door_pass/scripts/door_checking.py
+++ b/door_pass/scripts/door_checking.py
@@ -31,7 +31,7 @@ class DoorCheck(object):
         rospy.spin()
     
 if __name__ == '__main__':
-    rospy.init_node("door_pass_node")
+    rospy.init_node("door_check_node")
     checker=DoorCheck()
     checker.main()
     

--- a/door_pass/scripts/door_wait_and_pass.py
+++ b/door_pass/scripts/door_wait_and_pass.py
@@ -1,0 +1,141 @@
+#! /usr/bin/env python
+
+import rospy
+import actionlib
+from actionlib_msgs.msg import GoalStatusArray, GoalStatus
+from move_base_msgs.msg import MoveBaseAction
+from door_pass.door_utils import DoorUtils
+from mary_tts.msg import maryttsAction, maryttsGoal
+
+   
+class DoorWaitAndPass(object):
+    def __init__(self):
+        max_trans_vel=rospy.get_param("~/max_trans_vel", 0.15)
+        max_rot_vel=rospy.get_param("~/max_rot_vel", 0.4)
+        vel_scale_factor=rospy.get_param("~/vel_scale_factor", 2)
+        base_radius=rospy.get_param("~/base_radius", 0.31)
+        getting_further_counter_threshold=rospy.get_param("~/getting_further_counter_threshold", 5)
+        distance_to_success=rospy.get_param("~/distance_to_success", 0.2)
+        self.wait_timeout=rospy.get_param("~/wait_timeout", 60)
+        
+        self.door_utils=DoorUtils(max_trans_vel=max_trans_vel,
+                                  max_rot_vel=max_rot_vel,
+                                  vel_scale_factor=vel_scale_factor,
+                                  base_radius=base_radius,
+                                  getting_further_counter_threshold=getting_further_counter_threshold,
+                                  distance_to_success=distance_to_success)
+        
+        self.mon_nav_status_sub=rospy.Subscriber("/monitored_navigation/status", GoalStatusArray, self.mon_nav_status_cb)
+        
+        self.door_as=actionlib.SimpleActionServer('door_wait_and_pass', MoveBaseAction, execute_cb = self.execute_cb, auto_start=False) 
+        self.door_as.start()
+        self.door_as.register_preempt_callback(self.door_as_preempt_cb)        
+        self.mon_nav_executing=False
+        self.speaker = actionlib.SimpleActionClient('/speak', maryttsAction)
+        
+
+    def mon_nav_status_cb(self, data):
+        result=False
+        for goal in data.status_list:
+            if goal.status==GoalStatus.ACTIVE:
+                result=True
+                break
+        self.mon_nav_executing=result
+
+    def execute_cb(self, goal):
+        self.door_utils.activate()
+        max_trans_vel=rospy.get_param("~/max_trans_vel", 0.15)
+        max_rot_vel=rospy.get_param("~/max_rot_vel", 0.4)
+        vel_scale_factor=rospy.get_param("~/vel_scale_factor", 2)
+        base_radius=rospy.get_param("~/base_radius", 0.31)
+        getting_further_counter_threshold=rospy.get_param("~/getting_further_counter_threshold", 5)
+        distance_to_success=rospy.get_param("~/distance_to_success", 0.2)        
+        self.door_utils.set_params(max_trans_vel=max_trans_vel,
+                                  max_rot_vel=max_rot_vel,
+                                  vel_scale_factor=vel_scale_factor,
+                                  base_radius=base_radius,
+                                  getting_further_counter_threshold=getting_further_counter_threshold,
+                                  distance_to_success=distance_to_success)
+        
+        target_pose=goal.target_pose.pose
+        rospy.loginfo("Door wait and pass action server calling rotate towards pose")
+        self.door_utils.rotate_towards_pose(target_pose)
+        if self.door_as.is_preempt_requested():
+            self.finish_execution(GoalStatus.PREEMPTED)
+            return
+        self.waiting=True
+        open_count=0
+        wait_timer=rospy.Timer(rospy.Duration(self.wait_timeout), self.timer_cb, oneshot=True)
+        while self.waiting and open_count<4:
+            rospy.loginfo("Door wait and pass action server calling check door")
+            door_open=self.door_utils.check_door(target_pose)
+            if door_open:
+                open_count+=1
+            else:
+                open_count=0
+            if self.door_as.is_preempt_requested():
+                self.finish_execution(GoalStatus.PREEMPTED)
+                return
+            rospy.sleep(rospy.Duration(0.5))
+        wait_timer.shutdown()
+        if open_count==4:
+            rospy.loginfo("The door is open. Door wait and pass action server is calling pass door")
+            self.speaker.send_goal(maryttsGoal(text="I'm going to pass the door. Please hold it for me."))
+            success=self.door_utils.pass_door(target_pose)
+            if self.door_as.is_preempt_requested():
+                self.finish_execution(GoalStatus.PREEMPTED)
+                return
+            if success:
+                self.finish_execution(GoalStatus.SUCCEEDED)
+                self.speaker.send_goal(maryttsGoal(text="Great! Thank you for the help."))
+                return
+            else:
+                self.finish_execution(GoalStatus.ABORTED)
+                return
+        else:
+            rospy.loginfo("Timeout waiting for door to open. Disabling monitored navigation recoveries.")
+            current_mon_nav_recover_states=rospy.get_param("/monitored_navigation/recover_states/", {})
+            for mon_nav_recover_state in current_mon_nav_recover_states:
+                rospy.set_param("/monitored_navigation/recover_states/" + mon_nav_recover_state, [False,0])
+            self.finish_execution(GoalStatus.ABORTED)
+            #wait for mon nav to output failure and get recover states back on
+            timeout=0
+            while self.mon_nav_executing and not self.door_as.is_preempt_requested() and timeout<30:
+                rospy.loginfo("Waiting for monitored navigation to stop executing")
+                rospy.sleep(0.1)
+                timeout=timeout+1
+            rospy.loginfo("Monitored navigation stopped executing. Resetting monitored navigation recoveries.")
+            rospy.set_param("/monitored_navigation/recover_states/", current_mon_nav_recover_states)            
+            return
+    
+    def finish_execution(self, status):
+        rospy.loginfo("Door passing finished with outcome " + GoalStatus.to_string(status))
+        self.door_utils.deactivate()
+        if status==GoalStatus.SUCCEEDED:
+            self.door_as.set_succeeded()
+        if status==GoalStatus.ABORTED:
+            self.door_as.set_aborted()
+        if status==GoalStatus.PREEMPTED:
+            self.door_as.set_preempted()
+        
+
+    def door_as_preempt_cb(self):
+        self.door_utils.deactivate()
+
+    def timer_cb(self, event):
+        self.waiting=False
+
+    def main(self):
+        rospy.spin()
+    
+if __name__ == '__main__':
+    rospy.init_node("door_wait_and_pass_node")
+    passer=DoorWaitAndPass()
+    passer.main()
+    
+        
+    
+    
+    
+    
+

--- a/door_pass/scripts/door_wait_and_pass.py
+++ b/door_pass/scripts/door_wait_and_pass.py
@@ -63,10 +63,10 @@ class DoorWaitAndPass(object):
             return
 
         if self.stand_alone:
-            consecutive_opens=5
+            consecutive_open_secs=2.5
         else:
-            consecutive_opens=1
-        opened=self.door_utils.wait_door(self.wait_timeout, target_pose, 40, False, self.stand_alone, consecutive_opens)
+            consecutive_open_secs=0.1
+        opened=self.door_utils.wait_door(self.wait_timeout, target_pose, 40, False, self.stand_alone, consecutive_open_secs)
         
         if self.door_as.is_preempt_requested():
             self.finish_execution(GoalStatus.PREEMPTED)

--- a/door_pass/scripts/door_wait_and_pass.py
+++ b/door_pass/scripts/door_wait_and_pass.py
@@ -68,7 +68,7 @@ class DoorWaitAndPass(object):
         wait_timer=rospy.Timer(rospy.Duration(self.wait_timeout), self.timer_cb, oneshot=True)
         while self.waiting and open_count<4:
             rospy.loginfo("Door wait and pass action server calling check door")
-            door_open=self.door_utils.check_door(target_pose)
+            door_open=self.door_utils.check_door(target_pose, 40)
             if door_open:
                 open_count+=1
             else:

--- a/door_pass/scripts/door_waiting.py
+++ b/door_pass/scripts/door_waiting.py
@@ -58,7 +58,7 @@ class DoorWait(object):
         wait_timer=rospy.Timer(rospy.Duration(wait_timeout), self.timer_cb, oneshot=True)
         while self.waiting and open_count<4:
             rospy.loginfo("Door wait and pass action server calling check door")
-            door_open=self.door_utils.check_door(target_pose)
+            door_open=self.door_utils.check_door(target_pose, 40)
             if door_open:
                 open_count+=1
             else:

--- a/door_pass/scripts/door_waiting.py
+++ b/door_pass/scripts/door_waiting.py
@@ -54,7 +54,7 @@ class DoorWait(object):
             self.finish_execution(GoalStatus.PREEMPTED)
             return
         
-        opened=self.door_utils.wait_door(wait_timeout, target_pose, 40, True, 6)
+        opened=self.door_utils.wait_door(wait_timeout, target_pose, 40)
         
         if self.door_as.is_preempt_requested():
             self.finish_execution(GoalStatus.PREEMPTED)

--- a/door_pass/scripts/door_waiting.py
+++ b/door_pass/scripts/door_waiting.py
@@ -54,7 +54,7 @@ class DoorWait(object):
             self.finish_execution(GoalStatus.PREEMPTED)
             return
         
-        opened=self.door_utils.wait_door(wait_timeout, target_pose, 40, True, 4)
+        opened=self.door_utils.wait_door(wait_timeout, target_pose, 40, True, 6)
         
         if self.door_as.is_preempt_requested():
             self.finish_execution(GoalStatus.PREEMPTED)

--- a/door_pass/scripts/door_waiting.py
+++ b/door_pass/scripts/door_waiting.py
@@ -1,0 +1,99 @@
+#! /usr/bin/env python
+
+import rospy
+import actionlib
+from door_pass.msg import DoorWaitAction, DoorWaitResult
+from door_pass.door_utils import DoorUtils
+from mary_tts.msg import maryttsAction, maryttsGoal
+   
+class DoorWait(object):
+    def __init__(self):
+        max_trans_vel=rospy.get_param("~/max_trans_vel", 0.15)
+        max_rot_vel=rospy.get_param("~/max_rot_vel", 0.4)
+        vel_scale_factor=rospy.get_param("~/vel_scale_factor", 2)
+        base_radius=rospy.get_param("~/base_radius", 0.31)
+        getting_further_counter_threshold=rospy.get_param("~/getting_further_counter_threshold", 5)
+        distance_to_success=rospy.get_param("~/distance_to_success", 0.2)
+        
+        self.door_utils=DoorUtils(max_trans_vel=max_trans_vel,
+                                  max_rot_vel=max_rot_vel,
+                                  vel_scale_factor=vel_scale_factor,
+                                  base_radius=base_radius,
+                                  getting_further_counter_threshold=getting_further_counter_threshold,
+                                  distance_to_success=distance_to_success)
+        
+        
+        self.door_as=actionlib.SimpleActionServer('door_wait', DoorWaitAction, execute_cb = self.execute_cb, auto_start=False) 
+        self.door_as.start()
+        
+        self.waiting=False
+        self.speaker = actionlib.SimpleActionClient('/speak', maryttsAction)
+        
+
+    def execute_cb(self, goal):
+        self.door_utils.activate()
+        max_trans_vel=rospy.get_param("~/max_trans_vel", 0.15)
+        max_rot_vel=rospy.get_param("~/max_rot_vel", 0.4)
+        vel_scale_factor=rospy.get_param("~/vel_scale_factor", 2)
+        base_radius=rospy.get_param("~/base_radius", 0.31)
+        getting_further_counter_threshold=rospy.get_param("~/getting_further_counter_threshold", 5)
+        distance_to_success=rospy.get_param("~/distance_to_success", 0.2)        
+        self.door_utils.set_params(max_trans_vel=max_trans_vel,
+                                  max_rot_vel=max_rot_vel,
+                                  vel_scale_factor=vel_scale_factor,
+                                  base_radius=base_radius,
+                                  getting_further_counter_threshold=getting_further_counter_threshold,
+                                  distance_to_success=distance_to_success)
+        
+        target_pose=goal.target_pose.pose
+        wait_timeout=goal.wait_timeout
+        rospy.loginfo("Door wait and pass action server calling rotate towards pose")
+        self.door_utils.rotate_towards_pose(target_pose)
+        if self.door_as.is_preempt_requested():
+            self.door_utils.deactivate()
+            self.door_as.set_preempted()
+            return
+        self.waiting=True
+        open_count=0
+        wait_timer=rospy.Timer(rospy.Duration(wait_timeout), self.timer_cb, oneshot=True)
+        while self.waiting and open_count<4:
+            rospy.loginfo("Door wait and pass action server calling check door")
+            door_open=self.door_utils.check_door(target_pose)
+            if door_open:
+                open_count+=1
+            else:
+                open_count=0
+            if self.door_as.is_preempt_requested():
+                self.door_utils.deactivate()
+                self.door_as.set_preempted()
+                return
+            rospy.sleep(rospy.Duration(0.5))
+        wait_timer.shutdown()
+      
+        if open_count==4:
+            #self.speaker.send_goal(maryttsGoal(text="I'm going to pass the door. Please hold it for me."))
+            rospy.loginfo("The door is open.")
+        else:
+            rospy.loginfo("Timeout waiting for door to open.")
+           
+        self.door_utils.deactivate()        
+        self.door_as.set_succeeded(result=DoorWaitResult(open=(open_count==4)))
+    
+
+    def timer_cb(self, event):
+        self.waiting=False
+
+    def main(self):
+        rospy.spin()
+    
+if __name__ == '__main__':
+    rospy.init_node("door_wait_node")
+    waiter=DoorWait()
+    waiter.main()
+    
+        
+    
+    
+    
+    
+

--- a/door_pass/src/door_pass/door_utils.py
+++ b/door_pass/src/door_pass/door_utils.py
@@ -169,7 +169,7 @@ class DoorUtils(object):
         if not self.is_active:
             return False
       
-        opened=(open_count==consecutive_opens)
+        opened=(open_count==consecutive_opens+1)
         if log_to_mongo:
             try:
                 waypoint=rospy.wait_for_message("/current_node", String, 5)

--- a/door_pass/src/door_pass/door_utils.py
+++ b/door_pass/src/door_pass/door_utils.py
@@ -50,6 +50,9 @@ class DoorUtils(object):
         self.mongo_logger=message_proxy=MessageStoreProxy(collection='door_stats')
         self.speaker = SimpleActionClient('/speak', maryttsAction)
         self.just_spoken=False
+        self.wait_frequency=0.1
+        self.wait_elapsed=0.0
+        
         
     def activate(self):
         self.is_active=True
@@ -152,28 +155,30 @@ class DoorUtils(object):
         else:
             return False
     
-    def wait_door(self, wait_timeout, target_pose=None, n_closed=10, log_to_mongo=True, speak=True,consecutive_opens=4):
+    def wait_door(self, wait_timeout, target_pose=None, n_closed=10, log_to_mongo=True, speak=True,consecutive_open_secs=2):
         self.just_spoken=False
-        open_count=0
-        wait_elapsed=0.0
-        while self.is_active and wait_elapsed < wait_timeout and open_count<=consecutive_opens:
+        open_time=0
+        self.wait_elapsed=0.0
+        wait_timer=rospy.Timer(rospy.Duration(self.wait_frequency), self.wait_timer_cb)
+        while self.is_active and self.wait_elapsed < wait_timeout and abs(open_time-consecutive_open_secs)>(self.wait_frequency/2):
             rospy.loginfo("Door wait and pass action server calling check door")
             door_open=self.check_door(target_pose, n_closed, False)
             if door_open:
-                open_count+=1
+                open_time+=self.wait_frequency
             else:
-                open_count=0
-            if speak and open_count==1 and not self.just_spoken:
-                speak_timer=rospy.Timer(rospy.Duration(10), self.timer_cb, oneshot=True)
+                open_time=0
+            if speak and abs(open_time-self.wait_frequency)<0.01 and not self.just_spoken:
+                speak_timer=rospy.Timer(rospy.Duration(10), self.speak_timer_cb, oneshot=True)
                 self.just_spoken=True
                 self.speaker.send_goal(maryttsGoal(text="Please hold the door!"))
-            rospy.sleep(rospy.Duration(0.5))
-            wait_elapsed+=0.5
-        
+            rospy.sleep(rospy.Duration(self.wait_frequency))
+        wait_timer.shutdown()
         if not self.is_active:
             return False
       
-        opened=(open_count==consecutive_opens+1)
+        print open_time
+        print consecutive_open_secs
+        opened=(abs(open_time-consecutive_open_secs)<=(self.wait_frequency/2))
         if log_to_mongo:
             try:
                 waypoint=rospy.wait_for_message("/current_node", String, 5)
@@ -181,14 +186,17 @@ class DoorUtils(object):
                 self.mongo_logger.insert(DoorWaitStat(topological_map_name=topological_map_name,
                                                     waypoint=waypoint.data,
                                                     opened=opened,
-                                                    wait_time=wait_elapsed))
+                                                    wait_time=self.wait_elapsed))
             except Exception, e:
                 rospy.logwarn("Error logging door check " + str(e))
         return opened
         
     
-    def timer_cb(self, event):
+    def speak_timer_cb(self, event):
         self.just_spoken=False
+        
+    def wait_timer_cb(self, event):
+        self.wait_elapsed+=self.wait_frequency
     
     def pass_door(self, target_pose, speech=False): #assumes robot is facing the door and the door is open
         if self.is_active:

--- a/door_pass/src/door_pass/door_utils.py
+++ b/door_pass/src/door_pass/door_utils.py
@@ -106,7 +106,7 @@ class DoorUtils(object):
             self.stop_robot()
 
         
-    def check_door(self, target_pose=None): #assumes robot is facing the door
+    def check_door(self, target_pose=None, n_closed=10): #assumes robot is facing the door
         if self.is_active:
             robot_pose_sub = rospy.Subscriber("/robot_pose", Pose, self.pose_cb)
             scan_sub = rospy.Subscriber("/scan", LaserScan, self.scan_cb)
@@ -134,7 +134,7 @@ class DoorUtils(object):
                         open_door_counter=open_door_counter+1
             rospy.loginfo("Front laser door check results. closed_door_counter=" + str(closed_door_counter) + " , open_door_counter=" + str(open_door_counter))                        
             #log result in mongo
-            is_open=closed_door_counter<10
+            is_open=closed_door_counter<n_closed
             try:
                 waypoint=rospy.wait_for_message("/current_node", String, 5)
                 topological_map_name=rospy.get_param("/topological_map_name", "")

--- a/door_pass/src/door_pass/door_utils.py
+++ b/door_pass/src/door_pass/door_utils.py
@@ -6,8 +6,10 @@ from sensor_msgs.msg import LaserScan
 from geometry_msgs.msg import Twist, Pose
 from nav_msgs.msg import Path
 from door_pass.msg import DoorCheckStat
-
 from mongodb_store.message_store import MessageStoreProxy
+from actionlib import SimpleActionClient
+from mary_tts.msg import maryttsAction, maryttsGoal
+
 
 def clamp(value, lower, upper):
     return min(max(lower, value), upper)
@@ -44,8 +46,10 @@ class DoorUtils(object):
         self.new_pose_msg = False
         self.new_scan_msg = False
         
-        self.is_active=False        
+        self.is_active=False
+        self.is_waiting=False
         self.mongo_logger=message_proxy=MessageStoreProxy(collection='door_checks')
+        self.speaker = SimpleActionClient('/speak', maryttsAction)
         
     def activate(self):
         self.is_active=True
@@ -106,7 +110,7 @@ class DoorUtils(object):
             self.stop_robot()
 
         
-    def check_door(self, target_pose=None, n_closed=10): #assumes robot is facing the door
+    def check_door(self, target_pose=None, n_closed=10, log_to_mongo=True): #assumes robot is facing the door
         if self.is_active:
             robot_pose_sub = rospy.Subscriber("/robot_pose", Pose, self.pose_cb)
             scan_sub = rospy.Subscriber("/scan", LaserScan, self.scan_cb)
@@ -115,7 +119,7 @@ class DoorUtils(object):
             while (not self.new_pose_msg) or (not self.new_scan_msg):
                 rospy.sleep(0.05)
             if target_pose is None:
-                dist_to_goal=2 #use 3m                
+                dist_to_goal=2            
             else:
                 r_x = target_pose.position.x-self.pose_x
                 r_y = target_pose.position.y-self.pose_y
@@ -135,22 +139,56 @@ class DoorUtils(object):
             rospy.loginfo("Front laser door check results. closed_door_counter=" + str(closed_door_counter) + " , open_door_counter=" + str(open_door_counter))                        
             #log result in mongo
             is_open=closed_door_counter<n_closed
-            try:
-                waypoint=rospy.wait_for_message("/current_node", String, 5)
-                topological_map_name=rospy.get_param("/topological_map_name", "")
-                self.mongo_logger.insert(DoorCheckStat(topological_map_name=topological_map_name,
-                                                       waypoint=waypoint.data,
-                                                       is_open=is_open))
-            except Exception, e:
-                rospy.logwarn("Error logging door check " + str(e))
+            if log_to_mongo:
+                try:
+                    waypoint=rospy.wait_for_message("/current_node", String, 5)
+                    topological_map_name=rospy.get_param("/topological_map_name", "")
+                    self.mongo_logger.insert(DoorCheckStat(topological_map_name=topological_map_name,
+                                                        waypoint=waypoint.data,
+                                                        is_open=is_open))
+                except Exception, e:
+                    rospy.logwarn("Error logging door check " + str(e))
             return is_open
         else:
             return False
     
-    def pass_door(self, target_pose): #assumes robot is facing the door and the door is open
+    def wait_door(self, wait_timeout, target_pose=None, n_closed=10, log_to_mongo=True, speak=True,consecutive_opens=4):
+        self.is_waiting=True
+        open_count=0
+        
+        wait_timer=rospy.Timer(rospy.Duration(wait_timeout), self.wait_timer_cb, oneshot=True)
+        while self.is_active and self.is_waiting and open_count<consecutive_opens:
+            rospy.loginfo("Door wait and pass action server calling check door")
+            door_open=self.check_door(target_pose, n_closed, False)
+            if door_open:
+                open_count+=1
+            else:
+                open_count=0
+            if speak and open_count==1:
+                self.speaker.send_goal(maryttsGoal(text="Please hold the door!"))
+            rospy.sleep(rospy.Duration(0.5))
+        wait_timer.shutdown()
+        self.is_waiting=False
+        
+        if not self.is_active:
+            return False
+      
+        opened=(open_count==consecutive_opens)
+        if log_to_mongo:
+            print("LGOGLOGLGOLGOOLOG")
+        return opened
+        
+        
+    def wait_timer_cb(self, event):
+        self.is_waiting=False    
+        
+    
+    def pass_door(self, target_pose, speech=False): #assumes robot is facing the door and the door is open
         if self.is_active:
             robot_pose_sub = rospy.Subscriber("/robot_pose", Pose, self.pose_cb)
             scan_sub = rospy.Subscriber("/scan", LaserScan, self.scan_cb)
+            if speech:
+                self.speaker.send_goal(maryttsGoal(text="I'm going through now."))
             base_cmd=Twist()
             self.new_pose_msg=False
             self.new_scan_msg=False
@@ -172,6 +210,8 @@ class DoorUtils(object):
                 if (dist_to_goal<self.distance_to_success):
                     rospy.loginfo("Close enough to goal pose, door pass success.")
                     self.stop_robot()
+                    if speech:
+                        self.speaker.send_goal(maryttsGoal(text="Great! Thank you for the help."))
                     return True
                 if (prev_dist_to_goal < dist_to_goal):
                     getting_further_counter=getting_further_counter+1


### PR DESCRIPTION
This tackles https://github.com/strands-project/g4s_deployment/issues/84

It introduces a new action server `door_wait_and_pass` that waits for a predefined amount of time in front of a door when it is closed. If the door is open for more than 2 seconds, the robot speaks, saying he will go through and asking the person to keep holding the door.

The waiting time is defined via the param server, see https://github.com/bfalacerda/strands_apps/blob/indigo-devel/door_pass/scripts/door_wait_and_pass.py#L19

It also adds a stand-alone waiting node, to be used with the extended version of policy execution that is currently being developed for the TSC deployment. This has been tested for both the current and extended versions of policy execution.

Regardless, the only thing that needs to be done to use this is setting `door_wait_and_pass` instead of `doorPassing` as the nav action server between door edges in the topological map.
