### PR TITLE
Improve teardown/bringup mechanics

### DIFF
--- a/topological_roslaunch/scripts/bring_up_at_nodes.py
+++ b/topological_roslaunch/scripts/bring_up_at_nodes.py
@@ -21,6 +21,10 @@ if __name__ == '__main__':
 
     for c in config:
         # rospy.loginfo()
-        executor = BringUpAtNodes(bring_up_nodes = c['nodes'], launch_files = c['bring_up'])
+        if not c['bring_up']:
+            rospy.logwarn("No launch files were provided to bring up. Will not create bring up executor.")
+        else:
+            executor = BringUpAtNodes(bring_up_nodes = c['nodes'], launch_files = c['bring_up'])
+            rospy.loginfo("Created bring up executor.")
 
     rospy.spin()

--- a/topological_roslaunch/scripts/bring_up_at_nodes.py
+++ b/topological_roslaunch/scripts/bring_up_at_nodes.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 import rospy
-from topological_roslaunch import TearDownAtNodes
+from topological_roslaunch import BringUpAtNodes
 import yaml
 import sys
 
 if __name__ == '__main__':
 
-    rospy.init_node('tear_down_at_nodes')
+    rospy.init_node('bring_up_at_nodes')
 
     try:
         config_file =  rospy.get_param("~config")
@@ -21,6 +21,6 @@ if __name__ == '__main__':
 
     for c in config:
         # rospy.loginfo()
-        executor = TearDownAtNodes(tear_down_nodes = c['nodes'], launch_files = c['tear_down'])
+        executor = BringUpAtNodes(bring_up_nodes = c['nodes'], launch_files = c['bring_up'])
 
     rospy.spin()

--- a/topological_roslaunch/scripts/tear_down_at_nodes.py
+++ b/topological_roslaunch/scripts/tear_down_at_nodes.py
@@ -21,6 +21,10 @@ if __name__ == '__main__':
 
     for c in config:
         # rospy.loginfo()
-        executor = TearDownAtNodes(tear_down_nodes = c['nodes'], launch_files = c['tear_down'])
+        if not c['tear_down']:
+            rospy.logwarn("No launch files were provided to tear down. Will not create tear down executor.")
+        else:
+            executor = TearDownAtNodes(tear_down_nodes = c['nodes'], launch_files = c['tear_down'])
+            rospy.loginfo("Created tear down executor.")
 
     rospy.spin()

--- a/topological_roslaunch/src/topological_roslaunch/triggers.py
+++ b/topological_roslaunch/src/topological_roslaunch/triggers.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement 
+from __future__ import with_statement
 import rospy
 from std_msgs.msg import String
 from roslaunch_axserver.msg import launchAction, launchGoal
@@ -25,17 +25,17 @@ class LaunchWrapper(object):
 
     def tear_down(self):
         if self.launch_client is not None:
-            self.launch_client.cancel_all_goals()            
+            self.launch_client.cancel_all_goals()
 
-class TearDownAtNodes(object):
-
-    """ 
+class ToggleLaunchAtNodes(object):
+    """This is an abstract class which should be subclassed and have the
+    _update_topological_location method implemented.
 
     """
-    def __init__(self, tear_down_nodes, launch_files):
-        super(TearDownAtNodes, self).__init__()
-        
-        self.tear_down_nodes = set(tear_down_nodes)        
+    def __init__(self, nodes, launch_files):
+        super(ToggleLaunchAtNodes, self).__init__()
+
+        self.nodes = set(nodes)
         self.launch_goals = []
         self.launch_wrappers = []
         self.active_launch_files = []
@@ -43,14 +43,13 @@ class TearDownAtNodes(object):
         for lf in launch_files:
             goal = launchGoal()
             for k,v in lf.iteritems():
-                setattr(goal, k, v)      
+                setattr(goal, k, v)
 
             for i in range(len(goal.values)):
                 goal.values[i] = str(goal.values[i])
             self.launch_goals.append(goal)
 
         rospy.Subscriber('current_node', String, self._update_topological_location, queue_size = 1)
-
 
     def _launch_files_up(self):
         return len(self.launch_goals) == 0
@@ -65,10 +64,15 @@ class TearDownAtNodes(object):
             wrapper.tear_down()
             self.launch_goals.append(wrapper.launch_goal)
 
+    def _update_topological_location(self, node):
+        rospy.logerror("The function _update_topological_location is not implemented for the base class {0}. Please create a subclass and fill in the function there, or use the existing subclasses.".format(type(self).__name__))
 
-    def _update_topological_location(self, node):        
+class TearDownAtNodes(ToggleLaunchAtNodes):
+    def __init__(self, tear_down_nodes, launch_files):
+        super(TearDownAtNodes, self).__init__(tear_down_nodes, launch_files)
 
-        if node.data in self.tear_down_nodes:
+    def _update_topological_location(self, node):
+        if node.data in self.nodes:
             if self._launch_files_up():
                 rospy.loginfo('Tearing down launch files at %s' % node.data)
                 self._tear_down_launch_files()
@@ -77,4 +81,16 @@ class TearDownAtNodes(object):
             rospy.loginfo('Bringing launch files up at %s' % node.data)
             self._bring_up_launch_files()
 
+class BringUpAtNodes(ToggleLaunchAtNodes):
+    def __init__(self, bring_up_nodes, launch_files):
+        super(BringUpAtNodes, self).__init__(bring_up_nodes, launch_files)
 
+    def _update_topological_location(self, node):
+        if node.data in self.nodes:
+            if not self._launch_files_up():
+                rospy.loginfo('Bringing up launch files at %s' % node.data)
+                self._bring_up_launch_files()
+
+        elif self._launch_files_up():
+            rospy.loginfo('Tearing down files at %s' % node.data)
+            self._tear_down_launch_files()


### PR DESCRIPTION
Can now bring up launch files at a set of nodes, in the same way as with the
teardown.

The two classes used to do the launching now have a base class to reduce code
duplication.

Tested on my own machine, but needs testing on the robot to make sure behaviour is the same.

This provides the base functionality for strands-project/g4s_deployment#174