### PR TITLE
reduce required time of seeing the door open for the glass door.

### DIFF
--- a/door_pass/scripts/door_wait_and_move_base.py
+++ b/door_pass/scripts/door_wait_and_move_base.py
@@ -56,9 +56,9 @@ class DoorWaitAndMoveBase(object):
             return
 
         if self.stand_alone:
-            consecutive_open_secs=2.5
-        else:
             consecutive_open_secs=1.5
+        else:
+            consecutive_open_secs=0.5
         opened=self.door_utils.wait_door(self.wait_timeout, target_pose, False, self.stand_alone, consecutive_open_secs)
         
         if self.door_as.is_preempt_requested():


### PR DESCRIPTION
because now it only think its open when it sees a very small number of "closed" readings, and this might make it take to long (e.g., due to seeing people legs)